### PR TITLE
Improve price downloader to handle rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ COT_Swing_Analysis/
    # micro gold and micro crude oil
    python -m src.data.load_price MGC=F
    python -m src.data.load_price MCL=F
+   # if you hit rate limits from Yahoo Finance, increase the retry count
+   python -m src.data.load_price MGC=F --max-retries 5 --retry-delay 10
    ```
 3. Merge, build features and train a model
    ```bash

--- a/src/data/load_price.py
+++ b/src/data/load_price.py
@@ -1,7 +1,9 @@
 import os
+import time
 import pandas as pd
 import yfinance as yf
 import logging
+from yfinance.exceptions import YFRateLimitError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -11,10 +13,38 @@ if not logger.handlers:
     logger.addHandler(handler)
 
 
-def fetch_weekly_close(ticker: str, start_date: str = "2016-01-01", save_dir: str = "data/prices/") -> pd.DataFrame:
-    """Download daily prices for `ticker`, resample to weekly Friday close and save to CSV."""
-    logger.info(f"Downloading price for {ticker} since {start_date} via yfinance…")
-    df = yf.download(ticker, start=start_date, progress=False, auto_adjust=True)
+def fetch_weekly_close(
+    ticker: str,
+    start_date: str = "2016-01-01",
+    save_dir: str = "data/prices/",
+    max_retries: int = 3,
+    retry_delay: int = 5,
+) -> pd.DataFrame:
+    """Download daily prices for ``ticker`` and resample to weekly Friday close.
+
+    The function retries downloads when Yahoo Finance responds with a
+    :class:`~yfinance.exceptions.YFRateLimitError`.
+    """
+    logger.info(
+        f"Downloading price for {ticker} since {start_date} via yfinance…"
+    )
+    for attempt in range(1, max_retries + 1):
+        try:
+            df = yf.download(
+                ticker, start=start_date, progress=False, auto_adjust=True
+            )
+            break
+        except YFRateLimitError as exc:
+            if attempt == max_retries:
+                raise RuntimeError(
+                    f"Rate limit hit for {ticker} after {max_retries} attempts"
+                ) from exc
+            wait = retry_delay * attempt
+            logger.warning(f"Rate limited, retrying in {wait}s (attempt {attempt}/{max_retries})")
+            time.sleep(wait)
+    else:
+        # Should never reach here
+        raise RuntimeError(f"Failed to download data for {ticker}")
     if df.empty:
         raise RuntimeError(f"No data found for {ticker}")
     df = df[["Close"]].rename(columns={"Close": "etf_close"})
@@ -33,5 +63,13 @@ if __name__ == "__main__":
     parser.add_argument("ticker", help="Yahoo Finance ticker, e.g. MGC=F")
     parser.add_argument("--start", default="2016-01-01")
     parser.add_argument("--out-dir", default="data/prices/")
+    parser.add_argument("--max-retries", type=int, default=3, help="Number of retries when rate limited")
+    parser.add_argument("--retry-delay", type=int, default=5, help="Base delay between retries in seconds")
     args = parser.parse_args()
-    fetch_weekly_close(args.ticker, start_date=args.start, save_dir=args.out_dir)
+    fetch_weekly_close(
+        args.ticker,
+        start_date=args.start,
+        save_dir=args.out_dir,
+        max_retries=args.max_retries,
+        retry_delay=args.retry_delay,
+    )


### PR DESCRIPTION
## Summary
- add retry logic to `fetch_weekly_close` to gracefully handle `YFRateLimitError`
- expose retry options on the CLI
- document how to increase retries in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cdc3e4c08320a49b5dbe89c63748