### PR TITLE
Cleanup CHRIS support, enhance YF retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ COT_Swing_Analysis/
 ├── data/
 │   ├── raw/               # yearly COT Excel files
 │   ├── processed/         # cleaned datasets and features
-│   └── prices/            # price data downloaded from yfinance
+│   └── prices/            # price data downloaded from Yahoo Finance
 ├── src/
 │   ├── data/              # dataset utilities
 │   ├── features/          # feature engineering
@@ -25,18 +25,15 @@ COT_Swing_Analysis/
 2. Build the dataset and fetch micro-futures prices:
    ```bash
    python data/make_dataset.py --raw-dir data/raw --out-csv data/processed/cot_disagg_futures_2016_2025.csv
-   # micro gold and micro crude oil
-   python -m src.data.load_price MGC=F
-   python -m src.data.load_price MCL=F
-   # if you hit rate limits from Yahoo Finance, increase the retry count
-   python -m src.data.load_price MGC=F --max-retries 5 --retry-delay 10
+   # download crude and gold futures prices from Yahoo Finance
+   python -m src.data.load_price
    ```
 3. Merge, build features and train a model
    ```bash
    # example for gold
    python -m src.data.merge_cot_price \
        --cot data/processed/cot_disagg_futures_2016_2025.csv \
-       --price data/prices/MGC_F.csv \
+       --price data/prices/gc_weekly.csv \
        --out data/processed/merged_gold.csv
    python -m src.features.build_features \
        --merged data/processed/merged_gold.csv \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pandas
+pandas>=1.5.0
 numpy
 scikit-learn
 joblib
-yfinance
 fastapi
 uvicorn
+yfinance

--- a/src/data/load_price.py
+++ b/src/data/load_price.py
@@ -1,106 +1,146 @@
+"""
+Download historical crude oil and gold futures prices from Yahoo Finance.
+
+This script fetches daily data for ``CL=F`` and ``GC=F`` back to
+January 1, 2016 and saves both the raw daily prices and weekly
+(Friday-close) resampled series under ``data/prices``.
+
+It supports retry logic to handle transient network or rate-limit errors.
+The number of retries and delay between them can be configured via
+command-line arguments.
+
+Usage:
+    python -m src.data.load_price [--start YYYY-MM-DD] [--end YYYY-MM-DD] \
+        [--max-retries N] [--retry-delay SECONDS]
+
+This will create files like ``cl_daily.csv`` and ``cl_weekly.csv`` in the
+``data/prices`` directory.
+"""
+
 import os
 import time
+import argparse
+import logging
+
 import pandas as pd
 import yfinance as yf
-import logging
-from yfinance.exceptions import YFRateLimitError
+
+try:
+    from yfinance.exceptions import YFRateLimitError, YFInvalidPeriodError
+except Exception:  # fall back if yfinance lacks these exceptions
+    YFRateLimitError = Exception
+    YFInvalidPeriodError = Exception
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+_handler = logging.StreamHandler()
+_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
 if not logger.handlers:
-    logger.addHandler(handler)
+    logger.addHandler(_handler)
+
+SYMBOLS = {
+    "CL": "CL=F",
+    "GC": "GC=F",
+}
+
+DEFAULT_START = "2016-01-01"
+DEFAULT_END = pd.Timestamp.today().strftime("%Y-%m-%d")
+DEFAULT_RETRIES = 5
+DEFAULT_DELAY = 5
+
+DATA_DIR = os.path.join("data", "prices")
+os.makedirs(DATA_DIR, exist_ok=True)
 
 
-def fetch_weekly_close(
-    ticker: str,
-    start_date: str = "2016-01-01",
-    save_dir: str = "data/prices/",
-    max_retries: int = 3,
-    retry_delay: int = 5,
-) -> pd.DataFrame:
-    """Download daily prices for ``ticker`` and resample to weekly Friday close.
-
-    The function retries downloads when Yahoo Finance responds with a
-    :class:`~yfinance.exceptions.YFRateLimitError`.
-    """
-    logger.info(
-        f"Downloading price for {ticker} since {start_date} via yfinance…"
-    )
-
-    df = pd.DataFrame()
-    for attempt in range(1, max_retries + 1):
+def fetch_daily_history(ticker: str, start: str, end: str, max_retries: int, retry_delay: int) -> pd.DataFrame:
+    """Download daily history for ``ticker`` with retry logic."""
+    attempt = 0
+    while attempt < max_retries:
         try:
+            logger.info(
+                f"Downloading {ticker} from {start} to {end} (attempt {attempt + 1}/{max_retries})"
+            )
             df = yf.download(
                 ticker,
-                start=start_date,
+                start=start,
+                end=end,
                 progress=False,
-                auto_adjust=True,
-                threads=False,
+                auto_adjust=False,
             )
-
-    for attempt in range(1, max_retries + 1):
-        try:
-            df = yf.download(
-                ticker, start=start_date, progress=False, auto_adjust=True
-            )
-            break
-
-        except YFRateLimitError as exc:
-            if attempt == max_retries:
-                raise RuntimeError(
-                    f"Rate limit hit for {ticker} after {max_retries} attempts"
-                ) from exc
-            wait = retry_delay * attempt
-
+        except YFInvalidPeriodError as e:
+            # Some tickers require omitting the end date
             logger.warning(
-                f"Rate limited, retrying in {wait}s (attempt {attempt}/{max_retries})"
+                f"YFInvalidPeriodError for {ticker} with explicit end: {e}. Retrying with start-only…"
             )
-            time.sleep(wait)
+            df = yf.download(
+                ticker,
+                start=start,
+                progress=False,
+                auto_adjust=False,
+            )
+        except YFRateLimitError as e:
+            attempt += 1
+            if attempt >= max_retries:
+                logger.error(f"Rate limit exceeded for {ticker}: {e}")
+                raise
+            logger.warning(
+                f"Rate limit error for {ticker}: {e}. Retrying in {retry_delay}s…"
+            )
+            time.sleep(retry_delay)
+            continue
+        except Exception as e:
+            attempt += 1
+            if attempt >= max_retries:
+                logger.error(f"Failed to download {ticker} after {max_retries} attempts: {e}")
+                raise
+            logger.warning(f"Error downloading {ticker}: {e}. Retrying in {retry_delay}s…")
+            time.sleep(retry_delay)
             continue
 
-        if not df.empty:
+        if df is not None and not df.empty:
+            df.index.name = "Date"
+            return df
+
+        # Empty DataFrame triggers retry
+        attempt += 1
+        if attempt >= max_retries:
             break
-        if attempt == max_retries:
-            raise RuntimeError(f"No data found for {ticker}")
-        wait = retry_delay * attempt
         logger.warning(
-            f"Empty response, retrying in {wait}s (attempt {attempt}/{max_retries})"
+            f"No data returned for {ticker}. Retrying in {retry_delay}s…"
         )
-        time.sleep(wait)
+        time.sleep(retry_delay)
 
-            logger.warning(f"Rate limited, retrying in {wait}s (attempt {attempt}/{max_retries})")
-            time.sleep(wait)
-    else:
-        # Should never reach here
-        raise RuntimeError(f"Failed to download data for {ticker}")
-    if df.empty:
-        raise RuntimeError(f"No data found for {ticker}")
+    raise RuntimeError(f"Unable to fetch {ticker} after {max_retries} attempts")
 
-    df = df[["Close"]].rename(columns={"Close": "etf_close"})
-    df.index = pd.to_datetime(df.index)
-    weekly = df["etf_close"].resample("W-FRI").last().dropna().reset_index().rename(columns={"index": "week"})
-    os.makedirs(save_dir, exist_ok=True)
-    safe_name = ticker.replace("=", "_").replace("/", "_")
-    out_path = os.path.join(save_dir, f"{safe_name}.csv")
-    weekly.to_csv(out_path, index=False)
-    logger.info(f"Saved weekly prices to {out_path}")
+
+def resample_to_weekly(df: pd.DataFrame) -> pd.DataFrame:
+    """Resample a daily price DataFrame to weekly Friday closes."""
+    if "Close" not in df.columns:
+        raise KeyError("DataFrame must contain a 'Close' column")
+    weekly = df[["Close"]].resample("W-FRI").last()
+    weekly.index.name = "Date"
     return weekly
 
-if __name__ == "__main__":
-    import argparse
-    parser = argparse.ArgumentParser(description="Download and resample price data")
-    parser.add_argument("ticker", help="Yahoo Finance ticker, e.g. MGC=F")
-    parser.add_argument("--start", default="2016-01-01")
-    parser.add_argument("--out-dir", default="data/prices/")
-    parser.add_argument("--max-retries", type=int, default=3, help="Number of retries when rate limited")
-    parser.add_argument("--retry-delay", type=int, default=5, help="Base delay between retries in seconds")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download crude and gold futures via yfinance")
+    parser.add_argument("--start", default=DEFAULT_START, help="start date YYYY-MM-DD")
+    parser.add_argument("--end", default=DEFAULT_END, help="end date YYYY-MM-DD")
+    parser.add_argument("--max-retries", type=int, default=DEFAULT_RETRIES, help="number of download retries")
+    parser.add_argument("--retry-delay", type=int, default=DEFAULT_DELAY, help="seconds between retries")
     args = parser.parse_args()
-    fetch_weekly_close(
-        args.ticker,
-        start_date=args.start,
-        save_dir=args.out_dir,
-        max_retries=args.max_retries,
-        retry_delay=args.retry_delay,
-    )
+
+    for short, ticker in SYMBOLS.items():
+        daily = fetch_daily_history(ticker, args.start, args.end, args.max_retries, args.retry_delay)
+        daily_csv = os.path.join(DATA_DIR, f"{short.lower()}_daily.csv")
+        logger.info(f"Saving daily prices to {daily_csv}")
+        daily.to_csv(daily_csv)
+
+        weekly = resample_to_weekly(daily)
+        weekly_csv = os.path.join(DATA_DIR, f"{short.lower()}_weekly.csv")
+        logger.info(f"Saving weekly prices to {weekly_csv}")
+        weekly.to_csv(weekly_csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/merge_cot_price.py
+++ b/src/data/merge_cot_price.py
@@ -9,10 +9,11 @@ if not logger.handlers:
     logger.addHandler(handler)
 
 def merge_cot_with_price(cot_csv: str, price_csv: str, out_csv: str) -> pd.DataFrame:
-    """Merge processed COT data with price data on week."""
+    """Merge processed COT data with weekly futures prices."""
     cot = pd.read_csv(cot_csv, parse_dates=["report_date"])
-    price = pd.read_csv(price_csv, parse_dates=["week"])
+    price = pd.read_csv(price_csv, parse_dates=["date"])
     cot = cot.rename(columns={"report_date": "week"})
+    price = price.rename(columns={"date": "week", "close": "etf_close"})
     merged = pd.merge(cot, price, on="week", how="inner")
     merged = merged.sort_values("week").reset_index(drop=True)
     merged.to_csv(out_csv, index=False)

--- a/tests/test_load_price.py
+++ b/tests/test_load_price.py
@@ -1,18 +1,16 @@
 import pandas as pd
-from src.data.load_price import fetch_weekly_close
+from src.data.load_price import fetch_daily_history, resample_to_weekly
 
-class DummyDf(pd.DataFrame):
-    @property
-    def empty(self):
-        return False
 
-def test_fetch_weekly_close(tmp_path, monkeypatch):
+def test_fetch_and_resample(monkeypatch):
+    # dummy yfinance download returning 5 days of data
     def dummy_download(*args, **kwargs):
         idx = pd.date_range('2024-01-01', periods=5, freq='D')
-        return pd.DataFrame({'Close': [1,2,3,4,5]}, index=idx)
+        return pd.DataFrame({'Close': range(5)}, index=idx)
+
     monkeypatch.setattr('yfinance.download', dummy_download)
-    df = fetch_weekly_close("MGC=F", start_date="2024-01-01", save_dir=str(tmp_path))
-    assert not df.empty
-    assert set(df.columns) == {"week", "etf_close"}
-    csv_path = tmp_path / "MGC_F.csv"
-    assert csv_path.exists()
+    df_daily = fetch_daily_history('GC=F', start='2024-01-01', end='2024-01-06', max_retries=3, retry_delay=0)
+    assert not df_daily.empty
+    weekly = resample_to_weekly(df_daily)
+    assert not weekly.empty
+    assert weekly.index.freq is not None

--- a/tests/test_merge_cot_price.py
+++ b/tests/test_merge_cot_price.py
@@ -14,8 +14,8 @@ def test_merge(tmp_path):
         'sd_short': [2,3,1]
     })
     price = pd.DataFrame({
-        'week': pd.date_range('2024-01-05', periods=3, freq='W-FRI'),
-        'etf_close': [50,51,52]
+        'date': pd.date_range('2024-01-05', periods=3, freq='W-FRI'),
+        'close': [50, 51, 52]
     })
     cot_path = tmp_path / 'cot.csv'
     price_path = tmp_path / 'price.csv'


### PR DESCRIPTION
## Summary
- remove unused Nasdaq Data Link code and dependency
- refine yfinance downloader with YFInvalidPeriodError fallback
- document that price data comes from Yahoo Finance
- add tests for new loader
- handle missing yfinance exceptions gracefully

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841b0476ca4832082324e3caee9f5b7