### PR TITLE
Update merge_cot_price to use daily prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ COT_Swing_Analysis/
    ```bash
 
    # example for gold
-   python -m src.data.merge_cot_price \
-       --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv \
-       --price data/prices/gc_weekly.csv \
-       --out data/processed/merged_gc.csv \
+    python -m src.data.merge_cot_price \
+        --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv \
+        --price data/prices/gc_daily.csv \
+        --out data/processed/merged_gc.csv \
        --market "GOLD"
    python -m src.features.build_features \
        --merged data/processed/merged_gc.csv \

--- a/tests/test_merge_cot_price.py
+++ b/tests/test_merge_cot_price.py
@@ -14,8 +14,8 @@ def test_merge(tmp_path):
         'sd_short': [2,3,1]
     })
     price = pd.DataFrame({
-        'date': pd.date_range('2024-01-05', periods=3, freq='W-FRI'),
-        'close': [50, 51, 52]
+        'Date': pd.date_range('2024-01-01', periods=20, freq='D'),
+        'Close': range(20)
     })
     cot_path = tmp_path / 'cot.csv'
     price_path = tmp_path / 'price.csv'
@@ -25,4 +25,5 @@ def test_merge(tmp_path):
     merged = merge_cot_with_price(str(cot_path), str(price_path), str(out_path))
     assert not merged.empty
     assert 'etf_close' in merged.columns
+    assert 'week' in merged.columns
     assert out_path.exists()


### PR DESCRIPTION
## Summary
- merge COT data with daily price history
- update usage example to reference daily price CSV
- adapt merge test for daily price input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422954118883209f36290f1381120d