### PR TITLE
Fix date parsing in merge script

### DIFF
--- a/src/data/merge_cot_price.py
+++ b/src/data/merge_cot_price.py
@@ -81,7 +81,10 @@ def merge_cot_with_price(
     # `_load_and_clean_price` normalizes column names to lowercase and removes
     # any additional header rows.  Convert the date column to a timestamp and
     # standardize the close column name.
-    price["report_date"] = pd.to_datetime(price["date"])
+    price["report_date"] = pd.to_datetime(
+        price["date"], format="%Y-%m-%d", errors="coerce"
+    )
+    price = price.dropna(subset=["report_date"])
 
     if "close" in price.columns:
         price = price.rename(columns={"close": "etf_close"})


### PR DESCRIPTION
## Summary
- ensure prices with stray header rows don't cause datetime errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843230388d083208ef7d8c3f78cf737