### PR TITLE
Split COT dataset by market

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,11 @@ jobs:
 
     - name: Run CLI pipeline
       run: |
-        python -m src.data.merge_cot_price --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market "CRUDE OIL"
+        python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
+        python -m src.data.merge_cot_price --cot data/processed/cot_crude.csv --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market "CRUDE OIL"
         python -m src.features.build_features --merged data/processed/merged_cl.csv --out data/processed/features_cl.csv
         python -m src.models.train_model --features data/processed/features_cl.csv --model models/model_cl.joblib
-        python -m src.data.merge_cot_price --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --price data/prices/gc_weekly.csv --out data/processed/merged_gc.csv --market "GOLD"
+        python -m src.data.merge_cot_price --cot data/processed/cot_gold.csv --price data/prices/gc_weekly.csv --out data/processed/merged_gc.csv --market "GOLD"
         python -m src.features.build_features --merged data/processed/merged_gc.csv --out data/processed/features_gc.csv
         python -m src.models.train_model --features data/processed/features_gc.csv --model models/model_gc.joblib
 

--- a/README.md
+++ b/README.md
@@ -22,28 +22,40 @@ COT_Swing_Analysis/
    ```bash
    pip install -r requirements.txt
    ```
-2. Build the dataset and fetch micro-futures prices:
+2. Build the dataset, split by market and fetch micro-futures prices:
    ```bash
    python data/make_dataset.py --raw-dir data/raw --out-csv data/processed/cot_disagg_futures_2016_2025.csv
+   python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv \
+       --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
    # download crude and gold futures prices from Yahoo Finance
    python -m src.data.load_price
    ```
 3. Reproduce the entire pipeline with DVC
    ```bash
-
    # example for gold
     python -m src.data.merge_cot_price \
-        --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv \
+        --cot data/processed/cot_gold.csv \
         --price data/prices/gc_daily.csv \
-        --out data/processed/merged_gc.csv \
-       --market "GOLD"
-   python -m src.features.build_features \
-       --merged data/processed/merged_gc.csv \
+        --out data/processed/merged_gold.csv \
+        --market "GOLD"
+    python -m src.features.build_features \
+       --merged data/processed/merged_gold.csv \
        --out data/processed/features_gc.csv
-   python -m src.models.train_model \
+    python -m src.models.train_model \
        --features data/processed/features_gc.csv \
        --model models/model_gc.joblib
    # repeat for crude oil with the CL price file and market filter
+    python -m src.data.merge_cot_price \
+        --cot data/processed/cot_crude.csv \
+        --price data/prices/cl_daily.csv \
+        --out data/processed/merged_crude.csv \
+        --market "CRUDE OIL"
+    python -m src.features.build_features \
+        --merged data/processed/merged_crude.csv \
+        --out data/processed/features_cl.csv
+    python -m src.models.train_model \
+        --features data/processed/features_cl.csv \
+        --model models/model_cl.joblib
 
    dvc repro -f
 

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,41 +1,30 @@
 schema: '2.0'
 stages:
+  split_cot:
+    cmd: python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
+    deps:
+    - path: data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+    outs:
+    - path: data/processed/cot_gold.csv
+    - path: data/processed/cot_crude.csv
   merge_cl:
-    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_crude.csv
       --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market
       "CRUDE OIL"
     deps:
     - path: data/prices/cl_weekly.csv
-      hash: md5
-      md5: 93efafa0c65e8104d4a529f44bd51f0b
-      size: 96
-    - path: data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
-      hash: md5
-      md5: 26ee077f5ca47efadac06125c05bef99
-      size: 166368
+    - path: data/processed/cot_crude.csv
     outs:
     - path: data/processed/merged_cl.csv
-      hash: md5
-      md5: cc2522165052f612de769ea433bd2ab6
-      size: 1148
   merge_gc:
-    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_gold.csv
       --price data/prices/gc_weekly.csv --out data/processed/merged_gc.csv --market
       "GOLD"
     deps:
     - path: data/prices/gc_weekly.csv
-      hash: md5
-      md5: b3df74dd5164913f3fb57dee99c12ac3
-      size: 101
-    - path: data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
-      hash: md5
-      md5: 26ee077f5ca47efadac06125c05bef99
-      size: 166368
+    - path: data/processed/cot_gold.csv
     outs:
     - path: data/processed/merged_gc.csv
-      hash: md5
-      md5: 628cb4d78741ef52b17dbce845601019
-      size: 975
   features_cl:
     cmd: python -m src.features.build_features --merged data/processed/merged_cl.csv
       --out data/processed/features_cl.csv

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,16 +1,24 @@
 stages:
-  merge_cl:
-    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market "CRUDE OIL"
+  split_cot:
+    cmd: python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
     deps:
       - data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+    outs:
+      - data/processed/cot_gold.csv
+      - data/processed/cot_crude.csv
+
+  merge_cl:
+    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_crude.csv --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market "CRUDE OIL"
+    deps:
+      - data/processed/cot_crude.csv
       - data/prices/cl_weekly.csv
     outs:
       - data/processed/merged_cl.csv
 
   merge_gc:
-    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --price data/prices/gc_weekly.csv --out data/processed/merged_gc.csv --market "GOLD"
+    cmd: python -m src.data.merge_cot_price --cot data/processed/cot_gold.csv --price data/prices/gc_weekly.csv --out data/processed/merged_gc.csv --market "GOLD"
     deps:
-      - data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+      - data/processed/cot_gold.csv
       - data/prices/gc_weekly.csv
     outs:
       - data/processed/merged_gc.csv

--- a/src/data/merge_cot_price.py
+++ b/src/data/merge_cot_price.py
@@ -92,7 +92,8 @@ def merge_cot_with_price(
         # In case the cleaning step failed to normalize for some reason
         price = price.rename(columns={"Close": "etf_close"})
 
-    price = price[["report_date", "etf_close"]]
+    cols = ["report_date", "open", "high", "low", "etf_close", "volume"]
+    price = price[[c for c in cols if c in price.columns]]
 
     merged = pd.merge(cot, price, on="report_date", how="inner")
     merged["week"] = merged["report_date"] + pd.offsets.Week(weekday=4)

--- a/src/data/split_cot.py
+++ b/src/data/split_cot.py
@@ -1,0 +1,34 @@
+import os
+import argparse
+import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+_handler = logging.StreamHandler()
+_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+if not logger.handlers:
+    logger.addHandler(_handler)
+
+
+def split_cot(in_csv: str, gold_csv: str, crude_csv: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split combined COT CSV into separate gold and crude files."""
+    df = pd.read_csv(in_csv, parse_dates=["report_date"], low_memory=False)
+    gold = df[df["market_name"].str.contains("GOLD", case=False, na=False)].copy()
+    crude = df[df["market_name"].str.contains("CRUDE", case=False, na=False)].copy()
+
+    for out_path, subset in ((gold_csv, gold), (crude_csv, crude)):
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        subset.sort_values("report_date").to_csv(out_path, index=False)
+        logger.info(f"Wrote {len(subset)} rows to {out_path}")
+
+    return gold, crude
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Split combined COT data")
+    parser.add_argument("--in-csv", required=True, help="Combined COT CSV")
+    parser.add_argument("--gold", default="data/processed/cot_gold.csv")
+    parser.add_argument("--crude", default="data/processed/cot_crude.csv")
+    args = parser.parse_args()
+    split_cot(args.in_csv, args.gold, args.crude)

--- a/tests/test_merge_cot_price.py
+++ b/tests/test_merge_cot_price.py
@@ -15,7 +15,11 @@ def test_merge(tmp_path):
     })
     price = pd.DataFrame({
         'Date': pd.date_range('2024-01-01', periods=20, freq='D'),
-        'Close': range(20)
+        'Open': range(20),
+        'High': range(1,21),
+        'Low': range(20),
+        'Close': range(20),
+        'Volume': range(20)
     })
     cot_path = tmp_path / 'cot.csv'
     price_path = tmp_path / 'price.csv'
@@ -26,6 +30,8 @@ def test_merge(tmp_path):
     assert not merged.empty
     assert 'etf_close' in merged.columns
     assert 'week' in merged.columns
+    for col in ['open','high','low','volume']:
+        assert col in merged.columns
     assert out_path.exists()
 
 
@@ -43,7 +49,11 @@ def test_merge_two_level_header(tmp_path):
 
     price = pd.DataFrame({
         'Date': pd.date_range('2024-01-01', periods=20, freq='D'),
+        'Open': range(20),
+        'High': range(1,21),
+        'Low': range(20),
         'Close': range(20),
+        'Volume': range(20)
     })
 
     cot_path = tmp_path / 'cot.csv'
@@ -59,5 +69,7 @@ def test_merge_two_level_header(tmp_path):
     assert not merged.empty
     assert 'etf_close' in merged.columns
     assert 'week' in merged.columns
+    for col in ['open','high','low','volume']:
+        assert col in merged.columns
     assert out_path.exists()
 


### PR DESCRIPTION
## Summary
- split combined COT CSV into separate gold and crude files
- keep OHLCV columns when merging price data
- update tests and workflow for new files
- document updated commands in README
- adjust DVC pipeline for the new dataset layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843287075b08320bcfcfa3b908a3bcd