### PR TITLE
Add classifier training pipeline with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ COT_Swing_Analysis/
     python -m src.models.train_model \
        --features data/processed/features_gc.csv \
        --model models/model_gc.joblib
+   # or run the classification pipeline and save the best estimator
+    python -m src.models.train_classifier \
+        --features data/processed/features_gc.csv \
+        --model-out models/best_model_gc.pkl
    # repeat for crude oil with the CL price file and market filter
     python -m src.data.merge_cot_price \
         --cot data/processed/cot_crude.csv \
@@ -56,6 +60,10 @@ COT_Swing_Analysis/
     python -m src.models.train_model \
         --features data/processed/features_cl.csv \
         --model models/model_cl.joblib
+   # classification pipeline for crude oil
+    python -m src.models.train_classifier \
+        --features data/processed/features_cl.csv \
+        --model-out models/best_model_cl.pkl
 
    dvc repro -f
 

--- a/src/models/train_classifier.py
+++ b/src/models/train_classifier.py
@@ -1,0 +1,93 @@
+import argparse
+import pandas as pd
+import joblib
+from sklearn.model_selection import TimeSeriesSplit
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.base import clone
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+from pathlib import Path
+
+
+def train_and_evaluate(features_csv: str, model_out: str) -> None:
+    df = pd.read_csv(features_csv)
+    if 'target_dir' not in df.columns:
+        raise ValueError("features CSV must contain 'target_dir' column")
+
+    feature_cols = [c for c in df.columns if c != 'target_dir']
+    if 'week' in feature_cols:
+        feature_cols.remove('week')
+    X = df[feature_cols]
+    y = df['target_dir']
+
+    n_splits = 5 if len(X) > 6 else max(2, len(X) - 1)
+    tscv = TimeSeriesSplit(n_splits=n_splits)
+
+    classifiers = {
+        'LogisticRegression': LogisticRegression(max_iter=1000),
+        'RandomForest': RandomForestClassifier(n_estimators=100, random_state=42)
+    }
+
+    summary = {}
+
+    for name, clf in classifiers.items():
+        metrics = {'accuracy': [], 'precision': [], 'recall': [], 'f1': []}
+        fold = 1
+        for train_idx, test_idx in tscv.split(X):
+            X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+            y_train, y_test = y.iloc[train_idx], y.iloc[test_idx]
+
+            pipe = Pipeline([
+                ('scaler', StandardScaler()),
+                ('clf', clone(clf))
+            ])
+
+            pipe.fit(X_train, y_train)
+            preds = pipe.predict(X_test)
+
+            metrics['accuracy'].append(accuracy_score(y_test, preds))
+            metrics['precision'].append(precision_score(y_test, preds, zero_division=0))
+            metrics['recall'].append(recall_score(y_test, preds, zero_division=0))
+            metrics['f1'].append(f1_score(y_test, preds, zero_division=0))
+
+            print(f"{name} Fold {fold}: "
+                  f"acc={metrics['accuracy'][-1]:.3f} "
+                  f"precision={metrics['precision'][-1]:.3f} "
+                  f"recall={metrics['recall'][-1]:.3f} "
+                  f"F1={metrics['f1'][-1]:.3f}")
+            fold += 1
+
+        mean_metrics = {k: sum(v)/len(v) for k, v in metrics.items()}
+        print(f"{name} Mean: "
+              f"acc={mean_metrics['accuracy']:.3f} "
+              f"precision={mean_metrics['precision']:.3f} "
+              f"recall={mean_metrics['recall']:.3f} "
+              f"F1={mean_metrics['f1']:.3f}")
+        summary[name] = (mean_metrics['f1'], clf)
+
+    # select best model by mean F1
+    best_name, (best_f1, best_clf) = max(summary.items(), key=lambda x: x[1][0])
+    final_pipe = Pipeline([
+        ('scaler', StandardScaler()),
+        ('clf', best_clf)
+    ])
+    final_pipe.fit(X, y)
+
+    Path(model_out).parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(final_pipe, model_out)
+    print(f"Best model: {best_name} with mean F1={best_f1:.3f}")
+    print(f"Model saved to {model_out}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train classifiers on feature set")
+    parser.add_argument('--features', required=True, help='Path to features CSV')
+    parser.add_argument('--model-out', default='models/best_model.pkl', help='Path to save the best model pickle')
+    args = parser.parse_args()
+    train_and_evaluate(args.features, args.model_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_train_classifier.py
+++ b/tests/test_train_classifier.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import subprocess
+from src.features.build_features import build_features
+
+
+def test_train_classifier(tmp_path):
+    periods = 60
+    merged = pd.DataFrame({
+        'week': pd.date_range('2024-01-05', periods=periods, freq='W-FRI'),
+        'mm_long': range(10, 10 + periods),
+        'mm_short': range(5, 5 + periods),
+        'pm_long': range(8, 8 + periods),
+        'pm_short': range(3, 3 + periods),
+        'sd_long': range(6, 6 + periods),
+        'sd_short': range(2, 2 + periods),
+        'open_interest': [100] * periods,
+        'etf_close': [50 + (-1)**i * i for i in range(periods)]
+    })
+    merged_path = tmp_path / 'merged.csv'
+    merged.to_csv(merged_path, index=False)
+
+    features_path = tmp_path / 'features.csv'
+    df = build_features(str(merged_path), str(features_path))
+    df['target_dir'] = (df['return_1w'] > 0).astype(int)
+    df.to_csv(features_path, index=False)
+
+    model_path = tmp_path / 'best_model.pkl'
+    result = subprocess.run([
+        'python', '-m', 'src.models.train_classifier',
+        '--features', str(features_path),
+        '--model-out', str(model_path)
+    ], capture_output=True, text=True)
+
+    assert model_path.exists()
+    assert 'F1' in result.stdout
+
+    model_path.unlink()


### PR DESCRIPTION
## Summary
- implement `train_classifier.py` to train LogisticRegression and RandomForest models with time-series CV
- select best model by mean F1 score and save to disk
- add unit test covering CLI training script
- document manual execution of `train_classifier.py` in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68470f4727f48320a6cfdd4e22d1d2c6