### PR TITLE
Implement rolling evaluation script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,20 @@ Swap in your Crude feature file (`features_clf.csv`) and model
 (`best_model_cl.pkl`). The `--test-start` date can be earlier or later (e.g.
 `2022-07-01` to backtest the last 18 months). Commission stays at `0.0005`
 unless you want to model tighter or wider spreads. Include `--allow-shorts` if you wish to open short positions.
+
+### Rolling Window Backtests
+
+To gauge robustness over time, run the rolling evaluation script. It retrains at
+multiple start dates and summarizes returns, Sharpe ratios and drawdowns.
+
+```bash
+python scripts/rolling_eval.py \
+  --features data/processed/features_gc_clf.csv \
+  --model    src/models/best_model_gc.pkl \
+  --start    2017-01-01 \
+  --end      2024-01-01 \
+  --freq     6M \
+  --commission 0.0005
+```
+
+Results are written to `reports/rolling_backtest_gc.csv`.

--- a/scripts/rolling_eval.py
+++ b/scripts/rolling_eval.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from pathlib import Path
+import argparse
+import pandas as pd
+
+# ensure project root is on path so "src" is importable when running as script
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, REPO_ROOT)
+
+from src.eval.backtest import run_backtest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run rolling backtests")
+    parser.add_argument("--features", required=True, help="Features CSV")
+    parser.add_argument("--model", required=True, help="Trained model path")
+    parser.add_argument("--start", default="2017-01-01", help="Earliest test start date")
+    parser.add_argument(
+        "--end",
+        default=pd.Timestamp.today().strftime("%Y-%m-%d"),
+        help="Latest test start date",
+    )
+    parser.add_argument("--freq", default="6M", help="Frequency for rolling splits")
+    parser.add_argument("--commission", type=float, default=0.0005, help="Commission per round trip")
+
+    args = parser.parse_args()
+
+    dates = pd.date_range(args.start, args.end, freq=args.freq).strftime("%Y-%m-%d")
+
+    results = []
+    for ts in dates:
+        df_bt = run_backtest(
+            features_csv=args.features,
+            model_path=args.model,
+            test_start_date=ts,
+            commission_per_trade=args.commission,
+        )
+        cum = df_bt["cum_return"].iloc[-1]
+        ret = df_bt["strategy_ret"]
+        sharpe = ret.mean() / ret.std() * (52 ** 0.5) if ret.std() else 0
+        maxdd = ((1 + ret).cumprod().cummax() - (1 + ret).cumprod()).max()
+        results.append(
+            {
+                "test_start": ts,
+                "cum_return": cum,
+                "sharpe": sharpe,
+                "max_drawdown": maxdd,
+            }
+        )
+
+    df_results = pd.DataFrame(results)
+    reports_dir = Path("reports")
+    reports_dir.mkdir(exist_ok=True)
+    out_path = reports_dir / "rolling_backtest_gc.csv"
+    df_results.to_csv(out_path, index=False)
+    print(f"Wrote rolling backtest summary to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rolling_eval.py
+++ b/tests/test_rolling_eval.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import subprocess
+from sklearn.ensemble import RandomForestClassifier
+import joblib
+from pathlib import Path
+
+
+def test_rolling_eval(tmp_path):
+    # build small features dataset
+    periods = 10
+    df = pd.DataFrame({
+        'week': pd.date_range('2024-01-02', periods=periods, freq='W-TUE'),
+        'feature1': range(periods),
+        'target_dir': [0, 1] * (periods // 2) + ([0] if periods % 2 else []),
+        'etf_close': 100 + pd.Series(range(periods))
+    })
+    features_path = tmp_path / 'features.csv'
+    df.to_csv(features_path, index=False)
+
+    model = RandomForestClassifier(n_estimators=5, random_state=42)
+    model_path = tmp_path / 'model.pkl'
+    joblib.dump(model, model_path)
+
+    reports_dir = Path('reports')
+    if reports_dir.exists():
+        for f in reports_dir.iterdir():
+            f.unlink()
+    else:
+        reports_dir.mkdir()
+
+    result = subprocess.run([
+        'python', 'scripts/rolling_eval.py',
+        '--features', str(features_path),
+        '--model', str(model_path),
+        '--start', str(df.week.iloc[0].date()),
+        '--end', str(df.week.iloc[-2].date()),
+        '--freq', '2W',
+        '--commission', '0.0'
+    ], capture_output=True, text=True)
+
+    out_path = Path('reports/rolling_backtest_gc.csv')
+    assert out_path.exists(), result.stderr
+    out_df = pd.read_csv(out_path)
+    assert not out_df.empty


### PR DESCRIPTION
## Summary
- add `rolling_eval.py` script for rolling-window backtests
- include a pytest exercising the new CLI
- document rolling eval usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848574372ec8320bdc5c9854ae7a522