### PR TITLE
Add contrarian overlay for extreme spec long weeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ COT_Swing_Analysis/
        --out data/processed/features_gc.csv
     python -m src.data.build_classification_features \
        --in data/processed/features_gc.csv \
-       --out data/processed/class_features_gc.csv
+       --out data/processed/class_features_gc_extreme.csv
     python -m src.models.train_model \
        --features data/processed/features_gc.csv \
        --model models/model_gc.joblib
    # or run the classification pipeline and save the best estimator
     python -m src.models.train_classifier \
-        --features data/processed/class_features_gc.csv \
+        --features data/processed/class_features_gc_extreme.csv \
         --model-out models/best_model_gc.pkl
    # repeat for crude oil with the CL price file and market filter
     python -m src.data.merge_cot_price \
@@ -62,13 +62,13 @@ COT_Swing_Analysis/
         --out data/processed/features_cl.csv
     python -m src.data.build_classification_features \
         --in data/processed/features_cl.csv \
-        --out data/processed/class_features_cl.csv
+        --out data/processed/class_features_cl_extreme.csv
     python -m src.models.train_model \
         --features data/processed/features_cl.csv \
         --model models/model_cl.joblib
    # classification pipeline for crude oil
     python -m src.models.train_classifier \
-        --features data/processed/class_features_cl.csv \
+        --features data/processed/class_features_cl_extreme.csv \
         --model-out models/best_model_cl.pkl
 
    dvc repro -f
@@ -127,7 +127,7 @@ performance and generate a simple trading backtest.
 
 ```bash
 python scripts/run_eval.py \
-  --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/features_gc_clf.csv" \
+  --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/class_features_gc_extreme.csv" \
   --model    "src/models/best_model_gc.pkl" \
   --test-start 2023-01-01 \
   --commission 0.0005 \
@@ -145,14 +145,14 @@ python scripts/run_eval.py \
 
 ```bash
 python scripts/run_eval.py \
-  --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/features_clf.csv" \
+  --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/class_features_cl_extreme.csv" \
   --model    "src/models/best_model_cl.pkl" \
   --test-start 2023-01-01 \
   --commission 0.0005 \
  --allow-shorts
 ```
 
-Swap in your Crude feature file (`features_clf.csv`) and model
+Swap in your Crude feature file (`class_features_cl_extreme.csv`) and model
 (`best_model_cl.pkl`). The `--test-start` date can be earlier or later (e.g.
 `2022-07-01` to backtest the last 18 months). Commission stays at `0.0005`
 unless you want to model tighter or wider spreads. Include `--allow-shorts` if you wish to open short positions.
@@ -164,7 +164,7 @@ multiple start dates and summarizes returns, Sharpe ratios and drawdowns.
 
 ```bash
 python scripts/rolling_eval.py \
-  --features data/processed/features_gc_clf.csv \
+  --features data/processed/class_features_gc_extreme.csv \
   --model    src/models/best_model_gc.pkl \
   --start    2017-01-01 \
   --end      2024-01-01 \
@@ -174,8 +174,13 @@ python scripts/rolling_eval.py \
 
 Results are written to `reports/rolling_backtest_gc.csv`.
 
+## Contrarian Overlay
+
+When money managers' net-OI exceeds the 90th percentile, we invert the model's LONG
+signal to SHORT, to fade the speculator crowd.
+
+
 ### NOTES
-Contrarian overlay: in extreme speculator‐long conditions you might explicitly take the opposite side.
 
 Add a regime flag (e.g. vol_26w > threshold) and train separate models for high- vs low-vol regimes.
 

--- a/src/eval/backtest.py
+++ b/src/eval/backtest.py
@@ -76,6 +76,10 @@ def run_backtest(
 
     df_bt = test_df.copy()
     df_bt["signal"] = positions
+    # contrarian overlay: invert signal on extreme speculator-long weeks
+    if "extreme_spec_long" in df_bt.columns:
+        mask = df_bt["extreme_spec_long"] == 1
+        df_bt.loc[mask, "signal"] = -df_bt.loc[mask, "signal"]
     df_bt["entry_price"] = df_bt["etf_close"]
     df_bt["exit_price"] = df_bt["etf_close"].shift(-1)
     df_bt["raw_ret"] = (df_bt["exit_price"] - df_bt["entry_price"]) / df_bt["entry_price"]

--- a/tests/test_build_classification_features.py
+++ b/tests/test_build_classification_features.py
@@ -5,6 +5,7 @@ from src.data.build_classification_features import build_classification_features
 def test_build_classification_features(tmp_path):
     df = pd.DataFrame({
         'return_1w': [0.05, -0.02, 0.1],
+        'mm_net_pct_oi': [0.1, 0.2, 0.9],
         'other': [1, 2, 3]
     })
     in_path = tmp_path / 'features.csv'
@@ -12,5 +13,6 @@ def test_build_classification_features(tmp_path):
     out_path = tmp_path / 'class.csv'
     result = build_classification_features(str(in_path), str(out_path), th=0.0)
     assert 'target_dir' in result.columns
+    assert 'extreme_spec_long' in result.columns
     assert set(result['target_dir'].unique()) <= {0, 1}
     assert out_path.exists()

--- a/tests/test_contrarian_overlay.py
+++ b/tests/test_contrarian_overlay.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import joblib
+from pathlib import Path
+from src.eval.backtest import run_backtest
+
+
+class DummyModel:
+    def fit(self, X, y):
+        pass
+
+    def predict(self, X):
+        return [1] * len(X)
+
+
+def test_contrarian_overlay(tmp_path):
+    df = pd.DataFrame({
+        "week": pd.date_range("2024-01-02", periods=4, freq="W-TUE"),
+        "etf_close": [100, 101, 102, 103],
+        "mm_net_pct_oi": [0.1, 0.2, 0.9, 0.3],
+        "target_dir": [1, 1, 1, 1],
+    })
+    p90 = df["mm_net_pct_oi"].quantile(0.90)
+    df["extreme_spec_long"] = (df["mm_net_pct_oi"] >= p90).astype(int)
+
+    features_path = tmp_path / "features.csv"
+    df.to_csv(features_path, index=False)
+
+    model_path = tmp_path / "model.pkl"
+    joblib.dump(DummyModel(), model_path)
+
+    result = run_backtest(
+        str(features_path),
+        str(model_path),
+        str(df.week.iloc[1].date()),
+    )
+
+    # first row not extreme -> signal stays 1
+    # second row extreme -> signal flipped to -1
+    assert list(result["signal"]) == [1, -1]
+    assert result["strategy_ret"].iloc[0] > 0
+    assert result["strategy_ret"].iloc[1] < 0


### PR DESCRIPTION
## Summary
- flag `extreme_spec_long` when money managers' net percentage of OI is above the 90th percentile
- flip backtest signal on extreme weeks
- update CLI examples and README with new feature file paths
- document contrarian overlay
- add tests for new feature and overlay logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848949ec0308320842d65904d17246f