### PR TITLE
Fix contract code filtering

### DIFF
--- a/src/data/split_cot.py
+++ b/src/data/split_cot.py
@@ -14,8 +14,11 @@ if not logger.handlers:
 def split_cot(in_csv: str, gold_csv: str, crude_csv: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Split combined COT CSV into separate gold and crude files."""
     df = pd.read_csv(in_csv, parse_dates=["report_date"], low_memory=False)
-    gold = df[df["market_name"].str.contains("GOLD", case=False, na=False)].copy()
-    crude = df[df["market_name"].str.contains("CRUDE", case=False, na=False)].copy()
+    # Normalize as zero-padded strings so we can compare to literal codes.
+    # We prefer contract_code over market_name because the latter can change.
+    df["contract_code"] = df["contract_code"].astype(str).str.zfill(6)
+    gold = df[df["contract_code"] == "088691"].copy()
+    crude = df[df["contract_code"] == "067651"].copy()
 
     for out_path, subset in ((gold_csv, gold), (crude_csv, crude)):
         os.makedirs(os.path.dirname(out_path), exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure contract_code is zero padded before filtering for gold/crude
- add comment explaining why we rely on the code

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bbabbbac8320826b7cd882e4294d