### PR TITLE
Add CLI thresholds to rolling_eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ python scripts/rolling_eval.py \
   --start    2017-01-01 \
   --end      2024-01-01 \
   --freq     6M \
-  --commission 0.0005
+  --commission 0.0005 \
+  --thresholds 0.85,0.90,0.95
 ```
 
-Results are written to `reports/rolling_backtest_gc.csv`.
+Results are written to `reports/rolling_thresholds_gc.csv`.
 
 ## Contrarian Overlay
 

--- a/scripts/rolling_eval.py
+++ b/scripts/rolling_eval.py
@@ -1,8 +1,10 @@
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 import argparse
 import pandas as pd
+import numpy as np
 
 # ensure project root is on path so "src" is importable when running as script
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -11,50 +13,67 @@ sys.path.insert(0, REPO_ROOT)
 from src.eval.backtest import run_backtest
 
 
-def main() -> None:
+def main(argv: Optional[list] = None) -> None:
     parser = argparse.ArgumentParser(description="Run rolling backtests")
-    parser.add_argument("--features", required=True, help="Features CSV")
-    parser.add_argument("--model", required=True, help="Trained model path")
-    parser.add_argument("--start", default="2017-01-01", help="Earliest test start date")
+    parser.add_argument("--features", required=True, help="path to base features CSV")
+    parser.add_argument("--model", required=True, help="path to joblib model file")
+    parser.add_argument("--start", default="2017-01-01", help="first test-start date")
     parser.add_argument(
         "--end",
         default=pd.Timestamp.today().strftime("%Y-%m-%d"),
-        help="Latest test start date",
+        help="last test-start date",
     )
-    parser.add_argument("--freq", default="6M", help="Frequency for rolling splits")
-    parser.add_argument("--commission", type=float, default=0.0005, help="Commission per round trip")
+    parser.add_argument("--freq", default="6M", help="frequency for rolling splits")
+    parser.add_argument("--commission", type=float, default=0.0005, help="round-trip cost per trade")
+    parser.add_argument(
+        "--thresholds",
+        default="0.90",
+        help="comma-separated percentile(s) for contrarian overlay (e.g. 0.85,0.90,0.95)",
+    )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    dates = pd.date_range(args.start, args.end, freq=args.freq).strftime("%Y-%m-%d")
+    # parse thresholds into list of floats
+    thresh_list = [float(x) for x in args.thresholds.split(",")]
 
+    # generate test_start dates
+    test_starts = pd.date_range(args.start, args.end, freq=args.freq).strftime("%Y-%m-%d")
+
+    # container for all results
     results = []
-    for ts in dates:
-        df_bt = run_backtest(
-            features_csv=args.features,
-            model_path=args.model,
-            test_start_date=ts,
-            commission_per_trade=args.commission,
-        )
-        cum = df_bt["cum_return"].iloc[-1]
-        ret = df_bt["strategy_ret"]
-        sharpe = ret.mean() / ret.std() * (52 ** 0.5) if ret.std() else 0
-        maxdd = ((1 + ret).cumprod().cummax() - (1 + ret).cumprod()).max()
-        results.append(
-            {
+
+    for q in thresh_list:
+        # 1) load & flag extreme weeks based on percentile q
+        df = pd.read_csv(args.features, parse_dates=["week"])
+        p = df["mm_net_pct_oi"].quantile(q)
+        df["extreme_spec_long"] = (df["mm_net_pct_oi"] >= p).astype(int)
+        temp_csv = f"/tmp/features_gc_q{int(q*100)}.csv"
+        df.to_csv(temp_csv, index=False)
+
+        # 2) run rolling backtest for each split
+        for ts in test_starts:
+            bt = run_backtest(temp_csv, args.model, ts, args.commission)
+            if bt.empty:
+                cum, sharpe, maxdd = (np.nan, np.nan, np.nan)
+            else:
+                cum = bt["cum_return"].iloc[-1]
+                ret = bt["strategy_ret"]
+                sharpe = ret.mean() / ret.std() * np.sqrt(52) if ret.std() else np.nan
+                peak = (1 + ret).cumprod().cummax()
+                maxdd = ((peak - (1 + ret).cumprod()) / peak).max()
+            results.append({
+                "threshold": q,
                 "test_start": ts,
                 "cum_return": cum,
                 "sharpe": sharpe,
                 "max_drawdown": maxdd,
-            }
-        )
+            })
 
-    df_results = pd.DataFrame(results)
-    reports_dir = Path("reports")
-    reports_dir.mkdir(exist_ok=True)
-    out_path = reports_dir / "rolling_backtest_gc.csv"
-    df_results.to_csv(out_path, index=False)
-    print(f"Wrote rolling backtest summary to {out_path}")
+    # dump full summary
+    out_path = Path("reports/rolling_thresholds_gc.csv")
+    out_path.parent.mkdir(exist_ok=True)
+    pd.DataFrame(results).to_csv(out_path, index=False)
+    print(f"Wrote rolling threshold comparison to {out_path}")
 
 
 if __name__ == "__main__":

--- a/tests/test_rolling_eval.py
+++ b/tests/test_rolling_eval.py
@@ -12,7 +12,8 @@ def test_rolling_eval(tmp_path):
         'week': pd.date_range('2024-01-02', periods=periods, freq='W-TUE'),
         'feature1': range(periods),
         'target_dir': [0, 1] * (periods // 2) + ([0] if periods % 2 else []),
-        'etf_close': 100 + pd.Series(range(periods))
+        'etf_close': 100 + pd.Series(range(periods)),
+        'mm_net_pct_oi': [i / periods for i in range(periods)]
     })
     features_path = tmp_path / 'features.csv'
     df.to_csv(features_path, index=False)
@@ -35,10 +36,11 @@ def test_rolling_eval(tmp_path):
         '--start', str(df.week.iloc[0].date()),
         '--end', str(df.week.iloc[-2].date()),
         '--freq', '2W',
-        '--commission', '0.0'
+        '--commission', '0.0',
+        '--thresholds', '0.9'
     ], capture_output=True, text=True)
 
-    out_path = Path('reports/rolling_backtest_gc.csv')
+    out_path = Path('reports/rolling_thresholds_gc.csv')
     assert out_path.exists(), result.stderr
     out_df = pd.read_csv(out_path)
     assert not out_df.empty


### PR DESCRIPTION
## Summary
- enhance rolling_eval.py with --thresholds CLI option and improved help text
- compute overlay thresholds in rolling evaluation and write to new CSV
- update rolling_eval docs in README
- adjust rolling_eval tests for thresholds feature

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bb43b7b88320af2dfe6cfa2b13c3