### PR TITLE
Add automated weekly ETL pipeline

### DIFF
--- a/.github/workflows/weekly_etl.yml
+++ b/.github/workflows/weekly_etl.yml
@@ -1,0 +1,34 @@
+name: Weekly ETL
+
+on:
+  schedule:
+    - cron: "30 20 * * FRI"  # 3:30pm ET
+
+jobs:
+  etl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install --no-cache-dir -r requirements.txt google-api-python-client google-auth
+
+      - name: Run ETL
+        env:
+          GDRIVE_SA_KEY: ${{ secrets.GDRIVE_SA_KEY }}
+          RAW_DATA_FOLDER_ID: ${{ secrets.RAW_DATA_FOLDER_ID }}
+          RAW_DATA_DIR: src/data/raw
+        run: python scripts/weekly_etl.py
+
+      - name: Commit processed data
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add src/data/raw/*.xls src/data/processed/*.csv
+          git commit -m "ci: weekly ETL update" || echo "No changes"
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -300,3 +300,21 @@ Extend your GitHub workflow with a step that runs scripts/weekly_etl.py using th
 Optionally add a Dockerfile that installs the requirements and runs the script. This would allow executing the same pro
 
 Chain the two above so that once price + COT are updated, you re‐run your build_classification_features.py (with the 95% threshold) to produce today’s feature row.
+
+## Automated Weekly ETL
+
+The repository ships with a GitHub Actions workflow that runs every Friday at 3:30pm ET. It fetches any missing COT Excel files, updates prices and builds the latest feature sets automatically.
+
+### Prerequisites
+- `GDRIVE_SA_KEY` – Google service account JSON stored as a secret.
+- `RAW_DATA_FOLDER_ID` – Drive folder ID containing the raw COT files.
+
+Set `RAW_DATA_DIR` to override the local download directory when running the script manually.
+
+You can trigger the ETL outside of the schedule via the **workflow_dispatch** button on GitHub or by running:
+
+```bash
+python scripts/weekly_etl.py
+```
+
+with the same environment variables defined.

--- a/tests/test_weekly_etl.py
+++ b/tests/test_weekly_etl.py
@@ -1,0 +1,67 @@
+import io
+import json
+import zipfile
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def test_weekly_etl(tmp_path, monkeypatch):
+    # create a dummy zip containing one Excel file
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("test.xls", b"dummy")
+    buf.seek(0)
+
+    class DummyResp:
+        def __init__(self, data):
+            self.content = data
+
+        def raise_for_status(self):
+            pass
+
+    def dummy_get(url):
+        return DummyResp(buf.getvalue())
+
+    monkeypatch.setattr("requests.get", dummy_get)
+
+    calls = []
+
+    def dummy_call(cmd, *a, **k):
+        calls.append(cmd)
+
+    # load the script as a module so we can patch its functions
+    spec = importlib.util.spec_from_file_location("weekly_etl", "scripts/weekly_etl.py")
+    etl = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(etl)
+
+    monkeypatch.setattr(etl, "requests", pytest.importorskip("requests"))
+    monkeypatch.setattr(etl.requests, "get", dummy_get)
+    monkeypatch.setattr(etl.subprocess, "check_call", dummy_call)
+    monkeypatch.setattr(etl.service_account.Credentials, "from_service_account_info", lambda info: object())
+    monkeypatch.setattr(etl, "build", lambda *a, **kw: object())
+
+    class FakeDatetime:
+        @classmethod
+        def now(cls):
+            class D:  # noqa: D401
+                year = 2008
+            return D()
+
+    monkeypatch.setattr(etl, "datetime", FakeDatetime)
+
+    env = {
+        "GDRIVE_SA_KEY": json.dumps({"dummy": True}),
+        "RAW_DATA_FOLDER_ID": "1",
+        "RAW_DATA_DIR": str(tmp_path),
+    }
+    monkeypatch.setenv("GDRIVE_SA_KEY", env["GDRIVE_SA_KEY"])
+    monkeypatch.setenv("RAW_DATA_FOLDER_ID", env["RAW_DATA_FOLDER_ID"])
+    monkeypatch.setenv("RAW_DATA_DIR", env["RAW_DATA_DIR"])
+
+    exit_code = etl.main()
+    assert exit_code == 0
+
+    assert (tmp_path / "cot_2008.xls").exists()
+    assert any("make_dataset.py" in str(c[1]) if isinstance(c, list) else False for c in calls)


### PR DESCRIPTION
## Summary
- implement scheduled ETL script pulling COT history and running pipelines
- schedule weekly GitHub Action
- document automated ETL in README
- add regression test for the ETL script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b14d2173c83209d9c655fa45c7d11