### PR TITLE
Add OUT_CSV_PATH config for weekly_etl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Run CLI pipeline
       run: |
-        python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
+        python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2006_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
         python -m src.data.merge_cot_price --cot data/processed/cot_crude.csv --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market "CRUDE OIL"
         python -m src.features.build_features --merged data/processed/merged_cl.csv --out data/processed/features_cl.csv
         python -m src.data.build_classification_features --in data/processed/features_cl.csv --out data/processed/class_features_cl.csv --th 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Run CLI pipeline
       run: |
-        python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
+        python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2006_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
         python -m src.data.merge_cot_price --cot data/processed/cot_crude.csv --price data/prices/cl_weekly.csv --out data/processed/merged_cl.csv --market "CRUDE OIL"
         python -m src.features.build_features --merged data/processed/merged_cl.csv --out data/processed/features_cl.csv
         python -m src.models.train_model --features data/processed/features_cl.csv --model models/model_cl.joblib

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ COT_Swing_Analysis/
    ```
 2. Build the dataset, split by market and fetch micro-futures prices:
    ```bash
-   python data/make_dataset.py --raw-dir data/raw --out-csv data/processed/cot_disagg_futures_2016_2025.csv
-   python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv \
+   python data/make_dataset.py --raw-dir data/raw --out-csv data/processed/cot_disagg_futures_2006_2025.csv
+   python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2006_2025.csv \
        --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
    # download crude and gold futures prices from Yahoo Finance
    python -m src.data.load_price
@@ -232,7 +232,8 @@ Likewise schedule a daily job to:
 requires a Google service account key (`GDRIVE_SA_KEY`) so the workflow can
 authenticate, though the script now fetches the COT Excel files directly from the
 CFTC website.  Set `RAW_DATA_DIR` if you want the files stored somewhere other
-than `src/data/raw`.
+than `src/data/raw`. Use `OUT_CSV_PATH` to change where the consolidated CSV
+is written (defaults to `src/data/processed/cot_disagg_futures_2006_2025.csv`).
 
 When executed it first makes sure the 2006–2016 historical archive is present
 and that yearly `cot_YYYY.xls` files for 2017–2025 exist, downloading any
@@ -258,7 +259,7 @@ Copy requirements.txt and install the dependencies.
 
 Copy the repository files.
 
-Set the environment variables (`GDRIVE_SA_KEY` and optionally `RAW_DATA_DIR`) at runtime (e.g. `docker run -e GDRIVE_SA_KEY=...`).
+Set the environment variables (`GDRIVE_SA_KEY` and optionally `RAW_DATA_DIR` or `OUT_CSV_PATH`) at runtime (e.g. `docker run -e GDRIVE_SA_KEY=...`).
 
 Run python scripts/weekly_etl.py as the container’s entrypoint.
 
@@ -266,7 +267,7 @@ Once built, this Docker image can be used in CI (GitHub Actions supports running
 
 In short:
 
-Define the required env var: `GDRIVE_SA_KEY` (plus `RAW_DATA_DIR` if you want a custom destination).
+Define the required env var: `GDRIVE_SA_KEY` (plus `RAW_DATA_DIR` or `OUT_CSV_PATH` if you want custom destinations).
 
 Store the service‑account key in GitHub secrets or pass it when running a Docker container.
 
@@ -283,7 +284,7 @@ The repository ships with a GitHub Actions workflow that runs every Friday at 3:
 ### Prerequisites
 - `GDRIVE_SA_KEY` – Google service account JSON stored as a secret.
 
-Set `RAW_DATA_DIR` to override the local download directory when running the script manually.
+Set `RAW_DATA_DIR` to override the local download directory and `OUT_CSV_PATH` to change the consolidated CSV location when running the script manually.
 
 You can trigger the ETL outside of the schedule via the **workflow_dispatch** button on GitHub or by running:
 

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,9 +1,9 @@
 schema: '2.0'
 stages:
   split_cot:
-    cmd: python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
+    cmd: python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2006_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
     deps:
-    - path: data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+    - path: data/processed/cot_disagg_futures_gold_crude_2006_2025.csv
     outs:
     - path: data/processed/cot_gold.csv
     - path: data/processed/cot_crude.csv

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,8 +1,8 @@
 stages:
   split_cot:
-    cmd: python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2016_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
+    cmd: python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2006_2025.csv --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
     deps:
-      - data/processed/cot_disagg_futures_gold_crude_2016_2025.csv
+      - data/processed/cot_disagg_futures_gold_crude_2006_2025.csv
     outs:
       - data/processed/cot_gold.csv
       - data/processed/cot_crude.csv

--- a/scripts/weekly_etl.py
+++ b/scripts/weekly_etl.py
@@ -60,6 +60,11 @@ def main() -> int:
     raw_dir.mkdir(parents=True, exist_ok=True)
     os.environ.setdefault("RAW_DATA_FOLDER_ID", "")
 
+    out_csv = os.getenv(
+        "OUT_CSV_PATH",
+        "src/data/processed/cot_disagg_futures_2006_2025.csv",
+    )
+
     end_year = 2025
     years = range(2017, end_year + 1)
 
@@ -81,14 +86,14 @@ def main() -> int:
             "--raw-dir",
             str(raw_dir),
             "--out-csv",
-            "src/data/processed/cot_disagg_futures_2016_2025.csv",
+            out_csv,
         ])
         subprocess.check_call([
             sys.executable,
             "-m",
             "src.data.split_cot",
             "--in-csv",
-            "src/data/processed/cot_disagg_futures_2016_2025.csv",
+            out_csv,
             "--gold",
             "src/data/processed/cot_gold.csv",
             "--crude",

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--out-csv",
         type=str,
-        default="data/processed/cot_disagg_futures_2016_2025.csv",
+        default="data/processed/cot_disagg_futures_2006_2025.csv",
         help="Path where the consolidated CSV will be written",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- make weekly_etl.py honor `OUT_CSV_PATH` env var for its consolidated CSV
- default dataset filename now reflects the 2006–2025 range
- update docs and CI/Test workflow paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b64044b2083208de51d1fde2b7a7a