### PR TITLE
Clean test_weekly_etl

### DIFF
--- a/tests/test_weekly_etl.py
+++ b/tests/test_weekly_etl.py
@@ -41,8 +41,6 @@ def test_weekly_etl(tmp_path, monkeypatch):
             return DummyResp(hist_zip.getvalue())
         return DummyResp(year_zip.getvalue())
 
-        return DummyResp(buf.getvalue())
-
     monkeypatch.setattr("requests.get", dummy_get)
 
     calls = []
@@ -65,8 +63,6 @@ def test_weekly_etl(tmp_path, monkeypatch):
         @classmethod
         def now(cls):
             class D:  # noqa: D401
-
-                year = 2017
 
                 year = 2008
 


### PR DESCRIPTION
## Summary
- drop unreachable return from `dummy_get`
- remove redundant `year = 2017` assignment

## Testing
- `pytest tests/test_weekly_etl.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6815fe6c83208396f388d292ac8c