### PR TITLE
Clarify ETL output and add processed dir config

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,15 @@ Likewise schedule a daily job to:
 `scripts/weekly_etl.py` is intended for a CI or Docker environment.  It
 requires a Google service account key (`GDRIVE_SA_KEY`) so the workflow can
 authenticate, though the script now fetches the COT Excel files directly from the
-CFTC website.  Set `RAW_DATA_DIR` if you want the files stored somewhere other
-than `src/data/raw`. Use `OUT_CSV_PATH` to change where the consolidated CSV
+CFTC website. **No files are uploaded to Google Drive.**
+Set `RAW_DATA_DIR` if you want the files stored somewhere other
+than `src/data/raw`.
+Use `OUT_CSV_PATH` to change where the consolidated CSV
 is written (defaults to `src/data/processed/cot_disagg_futures_2006_2025.csv`).
+Set `PROCESSED_DIR` to move all processed outputs (gold/crude splits, feature
+files) to a different location.
+If the container's filesystem is ephemeral, point `RAW_DATA_DIR` and
+`PROCESSED_DIR` at a mounted drive so the downloads and outputs persist.
 
 When executed it first makes sure the 2006–2016 historical archive is present
 and that yearly `cot_YYYY.xls` files for 2017–2025 exist, downloading any
@@ -259,7 +265,7 @@ Copy requirements.txt and install the dependencies.
 
 Copy the repository files.
 
-Set the environment variables (`GDRIVE_SA_KEY` and optionally `RAW_DATA_DIR` or `OUT_CSV_PATH`) at runtime (e.g. `docker run -e GDRIVE_SA_KEY=...`).
+Set the environment variables (`GDRIVE_SA_KEY` and optionally `RAW_DATA_DIR`, `PROCESSED_DIR` or `OUT_CSV_PATH`) at runtime (e.g. `docker run -e GDRIVE_SA_KEY=...`).
 
 Run python scripts/weekly_etl.py as the container’s entrypoint.
 
@@ -267,7 +273,7 @@ Once built, this Docker image can be used in CI (GitHub Actions supports running
 
 In short:
 
-Define the required env var: `GDRIVE_SA_KEY` (plus `RAW_DATA_DIR` or `OUT_CSV_PATH` if you want custom destinations).
+Define the required env var: `GDRIVE_SA_KEY` (plus `RAW_DATA_DIR`, `PROCESSED_DIR` or `OUT_CSV_PATH` if you want custom destinations).
 
 Store the service‑account key in GitHub secrets or pass it when running a Docker container.
 
@@ -284,7 +290,7 @@ The repository ships with a GitHub Actions workflow that runs every Friday at 3:
 ### Prerequisites
 - `GDRIVE_SA_KEY` – Google service account JSON stored as a secret.
 
-Set `RAW_DATA_DIR` to override the local download directory and `OUT_CSV_PATH` to change the consolidated CSV location when running the script manually.
+Set `RAW_DATA_DIR` to override the local download directory and `OUT_CSV_PATH` to change the consolidated CSV location when running the script manually. Use `PROCESSED_DIR` if you need the processed outputs persisted to a mounted drive.
 
 You can trigger the ETL outside of the schedule via the **workflow_dispatch** button on GitHub or by running:
 

--- a/scripts/weekly_etl.py
+++ b/scripts/weekly_etl.py
@@ -60,9 +60,12 @@ def main() -> int:
     raw_dir.mkdir(parents=True, exist_ok=True)
     os.environ.setdefault("RAW_DATA_FOLDER_ID", "")
 
+    processed_dir = Path(os.getenv("PROCESSED_DIR", "src/data/processed"))
+    processed_dir.mkdir(parents=True, exist_ok=True)
+
     out_csv = os.getenv(
         "OUT_CSV_PATH",
-        "src/data/processed/cot_disagg_futures_2006_2025.csv",
+        str(processed_dir / "cot_disagg_futures_2006_2025.csv"),
     )
 
     end_year = 2025
@@ -95,9 +98,9 @@ def main() -> int:
             "--in-csv",
             out_csv,
             "--gold",
-            "src/data/processed/cot_gold.csv",
+            str(processed_dir / "cot_gold.csv"),
             "--crude",
-            "src/data/processed/cot_crude.csv",
+            str(processed_dir / "cot_crude.csv"),
         ])
         subprocess.check_call([
             sys.executable,
@@ -115,9 +118,9 @@ def main() -> int:
             "-m",
             "src.data.build_classification_features",
             "--in",
-            "src/data/processed/class_features_gc.csv",
+            str(processed_dir / "class_features_gc.csv"),
             "--out",
-            "src/data/processed/class_features_gc_extreme.csv",
+            str(processed_dir / "class_features_gc_extreme.csv"),
             "--th",
             "0.95",
         ])
@@ -126,9 +129,9 @@ def main() -> int:
             "-m",
             "src.data.build_classification_features",
             "--in",
-            "src/data/processed/class_features_cl.csv",
+            str(processed_dir / "class_features_cl.csv"),
             "--out",
-            "src/data/processed/class_features_cl_extreme.csv",
+            str(processed_dir / "class_features_cl_extreme.csv"),
             "--th",
             "0.95",
         ])

--- a/tests/test_weekly_etl.py
+++ b/tests/test_weekly_etl.py
@@ -74,10 +74,12 @@ def test_weekly_etl(tmp_path, monkeypatch):
         "GDRIVE_SA_KEY": json.dumps({"dummy": True}),
         "RAW_DATA_FOLDER_ID": "1",
         "RAW_DATA_DIR": str(tmp_path),
+        "PROCESSED_DIR": str(tmp_path / "processed"),
     }
     monkeypatch.setenv("GDRIVE_SA_KEY", env["GDRIVE_SA_KEY"])
     monkeypatch.setenv("RAW_DATA_FOLDER_ID", env["RAW_DATA_FOLDER_ID"])
     monkeypatch.setenv("RAW_DATA_DIR", env["RAW_DATA_DIR"])
+    monkeypatch.setenv("PROCESSED_DIR", env["PROCESSED_DIR"])
 
     exit_code = etl.main()
     assert exit_code == 0


### PR DESCRIPTION
## Summary
- add `PROCESSED_DIR` option in `weekly_etl.py`
- test the new environment variable in `test_weekly_etl`
- document that the ETL script doesn't upload to Drive and explain how to persist downloads and processed outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b68e3cb088320b7171ee63bcc6a46