### PR TITLE
Clarify merging requires daily prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ COT_Swing_Analysis/
    python data/make_dataset.py --raw-dir data/raw --out-csv data/processed/cot_disagg_futures_2006_2025.csv
    python -m src.data.split_cot --in-csv data/processed/cot_disagg_futures_gold_crude_2006_2025.csv \
        --gold data/processed/cot_gold.csv --crude data/processed/cot_crude.csv
-   # download crude and gold futures prices from Yahoo Finance
-   python -m src.data.load_price
-   # the older CHRIS-based downloader is kept only for reference.
+    # download crude and gold futures prices from Yahoo Finance
+    python -m src.data.load_price
+    # this writes both *_daily.csv and *_weekly.csv under data/prices
+    # Use the *daily* files (gc_daily.csv / cl_daily.csv) when merging with COT
+    # because the weekly closes fall on Friday, not the Tuesday COT date
+    # the older CHRIS-based downloader is kept only for reference.
    ```
 3. Reproduce the entire pipeline with DVC
    ```bash

--- a/src/data/merge_cot_price.py
+++ b/src/data/merge_cot_price.py
@@ -60,7 +60,9 @@ def merge_cot_with_price(
     cot_csv:
         Path to the CSV containing disaggregated COT data for multiple markets.
     price_csv:
-        Path to the daily price data for a single instrument.
+        Path to the daily price data for a single instrument. The merge expects
+        Tuesday COT dates to appear in this file. Using the weekly CSVs (with
+        Friday closes) will result in no matching rows.
     out_csv:
         Where the merged dataset should be written.
     market:


### PR DESCRIPTION
## Summary
- document that merge_cot_price should use the daily price CSVs
- warn about using weekly price files in merge_cot_price docstring

## Testing
- `pytest -q tests/test_merge_cot_price.py -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c69e2f7908320b8b031689fa8ac06