### PR TITLE
Add risk-on classification feature scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ COT_Swing_Analysis/
     python -m src.features.build_features \
        --merged data/processed/merged_gold.csv \
        --out data/processed/features_gc.csv
+    # risk‑on features for younger investors
+    python scripts/class_features_gc.py
+    # conservative overlay using the 95th percentile
     python -m src.data.build_classification_features \
        --in data/processed/features_gc.csv \
-       --out data/processed/class_features_gc_extreme.csv
+       --out data/processed/class_features_gc_extreme.csv \
+       --th 0.95
     python -m src.models.train_model \
        --features data/processed/features_gc.csv \
        --model models/model_gc.joblib
@@ -61,12 +65,16 @@ COT_Swing_Analysis/
         --price data/prices/cl_daily.csv \
         --out data/processed/merged_crude.csv \
         --market "CRUDE OIL"
-    python -m src.features.build_features \
-        --merged data/processed/merged_crude.csv \
-        --out data/processed/features_cl.csv
+   python -m src.features.build_features \
+       --merged data/processed/merged_crude.csv \
+       --out data/processed/features_cl.csv
+    # build risk‑on Crude features
+    python scripts/class_features_cl.py
+    # conservative overlay
     python -m src.data.build_classification_features \
         --in data/processed/features_cl.csv \
-        --out data/processed/class_features_cl_extreme.csv
+        --out data/processed/class_features_cl_extreme.csv \
+        --th 0.95
     python -m src.models.train_model \
         --features data/processed/features_cl.csv \
         --model models/model_cl.joblib
@@ -130,6 +138,15 @@ performance and generate a simple trading backtest.
 ### Gold Backtest
 
 ```bash
+# risk-on backtest
+python scripts/run_eval.py \
+  --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/class_features_gc.csv" \
+  --model    "src/models/best_model_gc.pkl" \
+  --test-start 2023-01-01 \
+  --commission 0.0005 \
+  --allow-shorts
+
+# conservative version using the overlay
 python scripts/run_eval.py \
   --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/class_features_gc_extreme.csv" \
   --model    "src/models/best_model_gc.pkl" \
@@ -148,6 +165,15 @@ python scripts/run_eval.py \
 ### Crude Backtest
 
 ```bash
+# risk-on backtest
+python scripts/run_eval.py \
+  --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/class_features_cl.csv" \
+  --model    "src/models/best_model_cl.pkl" \
+  --test-start 2023-01-01 \
+  --commission 0.0005 \
+  --allow-shorts
+
+# conservative version
 python scripts/run_eval.py \
   --features "/content/drive/MyDrive/Colab Notebooks/COT_Trading_System/src/data/processed/class_features_cl_extreme.csv" \
   --model    "src/models/best_model_cl.pkl" \

--- a/scripts/class_features_cl.py
+++ b/scripts/class_features_cl.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, REPO_ROOT)
+
+import argparse
+from src.data.build_classification_features import build_classification_features
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build classification-ready features for Crude"
+    )
+    parser.add_argument(
+        "--features",
+        default=str(Path("data/processed/features_cl.csv")),
+        help="Input features CSV",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(Path("data/processed/class_features_cl.csv")),
+        help="Output CSV path",
+    )
+    parser.add_argument("--th", type=float, default=0.0, help="Return threshold")
+    args = parser.parse_args()
+
+    build_classification_features(args.features, args.out, args.th)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/class_features_gc.py
+++ b/scripts/class_features_gc.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from pathlib import Path
+
+# ensure src is importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, REPO_ROOT)
+
+import argparse
+from src.data.build_classification_features import build_classification_features
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build classification-ready features for Gold"
+    )
+    parser.add_argument(
+        "--features",
+        default=str(Path("data/processed/features_gc.csv")),
+        help="Input features CSV",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(Path("data/processed/class_features_gc.csv")),
+        help="Output CSV path",
+    )
+    parser.add_argument("--th", type=float, default=0.0, help="Return threshold")
+    args = parser.parse_args()
+
+    build_classification_features(args.features, args.out, args.th)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/weekly_etl.py
+++ b/scripts/weekly_etl.py
@@ -159,6 +159,19 @@ def main() -> int:
                 "--in",
                 str(processed_dir / "features_gc.csv"),
                 "--out",
+                str(processed_dir / "class_features_gc.csv"),
+                "--th",
+                "0",
+            ]
+        )
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "src.data.build_classification_features",
+                "--in",
+                str(processed_dir / "features_gc.csv"),
+                "--out",
                 str(processed_dir / "class_features_gc_extreme.csv"),
                 "--th",
                 "0.95",
@@ -188,6 +201,19 @@ def main() -> int:
                 str(processed_dir / "merged_cl.csv"),
                 "--out",
                 str(processed_dir / "features_cl.csv"),
+            ]
+        )
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "src.data.build_classification_features",
+                "--in",
+                str(processed_dir / "features_cl.csv"),
+                "--out",
+                str(processed_dir / "class_features_cl.csv"),
+                "--th",
+                "0",
             ]
         )
         subprocess.check_call(


### PR DESCRIPTION
## Summary
- generate both standard and extreme classification features in `weekly_etl.py`
- add helper scripts `class_features_gc.py` and `class_features_cl.py`
- document new risk-on options in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8669b8508320bdc390c8604c199c